### PR TITLE
Scroll Element into View: Preserve Hash Route when scrolling

### DIFF
--- a/scroll-element-into-view/README.md
+++ b/scroll-element-into-view/README.md
@@ -1,6 +1,6 @@
 # Scroll Element into View
 
-This project is the result of a technical spike and it's about to scroll different sections of the website into view after the respected navigation item has been clicked.
+This project is the result of a technical spike and it's about to scroll different sections of the website into view after the respected navigation item has been clicked. We also want to preserve the hash routing functionality so that users can share different sections of the website via a URL link.
 
 I used `useRef` hook to gain access to the DOM element which I can call `scrollIntoView` function on a click event. This hook is one of the escape hatches of React.
 
@@ -17,3 +17,8 @@ $ yarn dev
 - [React API Reference - useRef](https://react.dev/reference/react/useRef)
 - [Manipulating the DOM with Refs](https://react.dev/learn/manipulating-the-dom-with-refs)
 - [HTML Element scrollIntoView() method](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView)
+
+Preserve the Hash Routing
+
+- [Changing the URL hash without scrolling in Javascript](https://www.sean-lloyd.com/post/changing-the-url-hash-without-scrolling-javascript/)
+- [History: pushState() method](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState)

--- a/scroll-element-into-view/index.html
+++ b/scroll-element-into-view/index.html
@@ -1,13 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scroll Element into View</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
 </html>

--- a/scroll-element-into-view/src/components/Header.jsx
+++ b/scroll-element-into-view/src/components/Header.jsx
@@ -5,8 +5,9 @@ export default function Header({
   blogSectionRef,
   contactSectionRef,
 }) {
-  function handleMenuItemClick(e, ref) {
+  function handleMenuItemClick(e, ref, hashString) {
     e.preventDefault();
+    history.pushState({}, "", `#${hashString}`);
     ref.current.scrollIntoView({ behavior: "smooth" });
   }
 
@@ -18,7 +19,9 @@ export default function Header({
           <li>
             <a
               href="#expertise"
-              onClick={(e) => handleMenuItemClick(e, expertiseSectionRef)}
+              onClick={(e) =>
+                handleMenuItemClick(e, expertiseSectionRef, "expertise")
+              }
             >
               Expertise
             </a>
@@ -26,7 +29,7 @@ export default function Header({
           <li>
             <a
               href="#blog"
-              onClick={(e) => handleMenuItemClick(e, blogSectionRef)}
+              onClick={(e) => handleMenuItemClick(e, blogSectionRef, "blog")}
             >
               Blog
             </a>
@@ -34,7 +37,9 @@ export default function Header({
           <li>
             <a
               href="#contact"
-              onClick={(e) => handleMenuItemClick(e, contactSectionRef)}
+              onClick={(e) =>
+                handleMenuItemClick(e, contactSectionRef, "contact")
+              }
             >
               Contact
             </a>


### PR DESCRIPTION
- Makes sure that hash routing is preserved even when the default behaviour of the anchor element click is prevented.
- Uses `history.pushState()` to accomplish this programmatically.
- Updates website title